### PR TITLE
Misc. Changes

### DIFF
--- a/gamemodes/nzombies/entities/entities/drop_bloodmoney/shared.lua
+++ b/gamemodes/nzombies/entities/entities/drop_bloodmoney/shared.lua
@@ -18,7 +18,7 @@ function ENT:Initialize()
 	
 	self:SetModel("models/nzpowerups/bloodmoney.mdl")
 	--self:PhysicsInit(SOLID_VPHYSICS)
-	self:PhysicsInitSphere(50, "default_silent")
+	self:PhysicsInitSphere(60, "default_silent")
 	self:SetMoveType(MOVETYPE_NONE)
 	self:SetSolid(SOLID_NONE)
 	if SERVER then
@@ -32,20 +32,28 @@ function ENT:Initialize()
 	self:SetColor( Color(255,200,0) )
 	--self:SetTrigger(true)
 	
-	timer.Create( self:EntIndex().."_deathtimer", 30, 1, function()
+	--[[timer.Create( self:EntIndex().."_deathtimer", 30, 1, function()
 		if IsValid(self) then
 			timer.Destroy(self:EntIndex().."_deathtimer")
 			if SERVER then
 				self:Remove()
 			end			
 		end
-	end)
+	end)]]
+	
+	self.RemoveTime = CurTime() + 30
 end
 
 if SERVER then
 	function ENT:StartTouch(hitEnt)
 		if (hitEnt:IsValid() and hitEnt:IsPlayer()) then
 			hitEnt:GivePoints(self:GetPoints())
+			self:Remove()
+		end
+	end
+	
+	function ENT:Think()
+		if self.RemoveTime and CurTime() > self.RemoveTime then
 			self:Remove()
 		end
 	end

--- a/gamemodes/nzombies/entities/entities/drop_powerup/shared.lua
+++ b/gamemodes/nzombies/entities/entities/drop_powerup/shared.lua
@@ -20,7 +20,7 @@ function ENT:Initialize()
 	self:SetModelScale(nzPowerUps:Get(self:GetPowerUp()).scale, 0)
 	
 	--self:PhysicsInit(SOLID_VPHYSICS)
-	self:PhysicsInitSphere(50, "default_silent")
+	self:PhysicsInitSphere(60, "default_silent")
 	self:SetMoveType(MOVETYPE_NONE)
 	self:SetSolid(SOLID_NONE)
 	if SERVER then
@@ -34,20 +34,27 @@ function ENT:Initialize()
 	self:SetColor( Color(255,200,0) )
 	--self:SetTrigger(true)
 	
-	timer.Create( self:EntIndex().."_deathtimer", 30, 1, function()
+	--[[timer.Create( self:EntIndex().."_deathtimer", 30, 1, function()
 		if IsValid(self) then
 			timer.Destroy(self:EntIndex().."_deathtimer")
 			if SERVER then
 				self:Remove()
 			end			
 		end
-	end)
+	end)]]
+	self.RemoveTime = CurTime() + 30
 end
 
 if SERVER then
 	function ENT:StartTouch(hitEnt)
 		if (hitEnt:IsValid() and hitEnt:IsPlayer()) then
 			nzPowerUps:Activate(self:GetPowerUp(), hitEnt)
+			self:Remove()
+		end
+	end
+	
+	function ENT:Think()
+		if self.RemoveTime and CurTime() > self.RemoveTime then
 			self:Remove()
 		end
 	end

--- a/gamemodes/nzombies/entities/entities/drop_tombstone/shared.lua
+++ b/gamemodes/nzombies/entities/entities/drop_tombstone/shared.lua
@@ -19,7 +19,7 @@ function ENT:Initialize()
 	self:SetModel("models/props_c17/gravestone003a.mdl")
 	
 	--self:PhysicsInit(SOLID_VPHYSICS)
-	self:PhysicsInitSphere(50, "default_silent")
+	self:PhysicsInitSphere(60, "default_silent")
 	self:SetMoveType(MOVETYPE_NONE)
 	self:SetSolid(SOLID_NONE)
 	if SERVER then
@@ -36,14 +36,16 @@ function ENT:Initialize()
 		self:SetUseType(SIMPLE_USE)
 	end
 	
-	timer.Create( self:EntIndex().."_deathtimer", 100, 1, function()
+	--[[timer.Create( self:EntIndex().."_deathtimer", 100, 1, function()
 		if self:IsValid() then
 			timer.Destroy(self:EntIndex().."_deathtimer")
 			if SERVER then
 				self:Remove()
 			end
 		end
-	end)
+	end)]]
+	
+	--self.RemoveTime = CurTime() + 120
 end
 
 if SERVER then
@@ -67,7 +69,23 @@ if SERVER then
 			end
 			nzWeps:GiveMaxAmmo(hitEnt)
 			
-			timer.Destroy(self:EntIndex().."_deathtimer")
+			--timer.Destroy(self:EntIndex().."_deathtimer")
+			self:Remove()
+		end
+	end
+	
+	function ENT:Think()
+		if !self.RemoveTime then
+			local ply = self:GetPerkOwner()
+			if IsValid(ply) then
+				if ply:Alive() and ply:GetNotDowned() and (ply:IsPlaying() or ply:IsInCreative()) then
+					self.RemoveTime = CurTime() + 90
+				end
+			else
+				-- Man, the player must've disconnected or crashed :/
+				self:Remove()
+			end
+		elseif self.RemoveTime and CurTime() > self.RemoveTime then
 			self:Remove()
 		end
 	end

--- a/gamemodes/nzombies/entities/entities/drop_vulture/shared.lua
+++ b/gamemodes/nzombies/entities/entities/drop_vulture/shared.lua
@@ -88,7 +88,7 @@ function ENT:Initialize()
 	end
 	self:SetModel(vulturedrops[self:GetDropType()].model)
 
-	self:PhysicsInitSphere(50, "default_silent")
+	self:PhysicsInitSphere(60, "default_silent")
 	self:SetMoveType(MOVETYPE_NONE)
 	self:SetSolid(SOLID_NONE)
 	if SERVER then
@@ -101,14 +101,16 @@ function ENT:Initialize()
 	self:DrawShadow(false)
 	self.DeathTimer = 30
 
-	timer.Create( self:EntIndex().."_deathtimer", vulturedrops[self:GetDropType()].timer, 1, function()
+	--[[timer.Create( self:EntIndex().."_deathtimer", vulturedrops[self:GetDropType()].timer, 1, function()
 		if IsValid(self) then
 			timer.Destroy(self:EntIndex().."_deathtimer")
 			if SERVER then
 				self:Remove()
 			end
 		end
-	end)
+	end)]]
+	
+	self.RemoveTime = CurTime() + vulturedrops[self:GetDropType()].timer
 
 	vulturedrops[self:GetDropType()].initialize(self)
 end
@@ -122,6 +124,12 @@ if SERVER then
 					self:Remove()
 				end
 			end
+		end
+	end
+	
+	function ENT:Think()
+		if self.RemoveTime and CurTime() > self.RemoveTime then
+			self:Remove()
 		end
 	end
 end

--- a/gamemodes/nzombies/entities/entities/edit_dynlight.lua
+++ b/gamemodes/nzombies/entities/entities/edit_dynlight.lua
@@ -55,6 +55,8 @@ function ENT:SetupDataTables()
 	self:NetworkVar( "Int",	1, "Size", { KeyName = "size", Edit = { type = "Int", min = 0, max = 1000, order = 3 } }  )
 	
 	self:NetworkVar( "Int",	2, "Style", { KeyName = "style", Edit = { type = "Int", min = 0, max = 12, order = 4 } }  )
+	
+	self:NetworkVar( "Bool", 0, "Elec", { KeyName = "electricity", Edit = { type = "Boolean" } }  )
 
 	if ( SERVER ) then
 
@@ -63,6 +65,7 @@ function ENT:SetupDataTables()
 		self:SetBrightness( 2 )
 		self:SetSize(256)
 		self:SetStyle(0) -- Standard bright all the time
+		self:SetElec(false)
 
 	end
 
@@ -70,25 +73,27 @@ end
 
 if CLIENT then
 	function ENT:Draw()
-		local size = self:GetSize()
-		if !self.LightSize or self.LightSize != size then
-			self:SetRenderBounds(Vector(-size, -size, -size), Vector(size, size, size))
-			self.LightSize = size
-		end
-		local color = self:GetLightColor() * 255
-		local brightness = self:GetBrightness()
-		local style = self:GetStyle()
-		local dlight = DynamicLight( self:EntIndex() )
-		if ( dlight ) then
-			dlight.pos = self:GetPos()
-			dlight.r = color[1]
-			dlight.g = color[2]
-			dlight.b = color[3]
-			dlight.brightness = brightness
-			dlight.Decay = 1000
-			dlight.Size = size
-			dlight.DieTime = CurTime() + 1
-			dlight.Style = style
+		if !self:GetElec() or nzElec.Active then
+			local size = self:GetSize()
+			if !self.LightSize or self.LightSize != size then
+				self:SetRenderBounds(Vector(-size, -size, -size), Vector(size, size, size))
+				self.LightSize = size
+			end
+			local color = self:GetLightColor() * 255
+			local brightness = self:GetBrightness()
+			local style = self:GetStyle()
+			local dlight = DynamicLight( self:EntIndex() )
+			if ( dlight ) then
+				dlight.pos = self:GetPos()
+				dlight.r = color[1]
+				dlight.g = color[2]
+				dlight.b = color[3]
+				dlight.brightness = brightness
+				dlight.Decay = 1000
+				dlight.Size = size
+				dlight.DieTime = CurTime() + 1
+				dlight.Style = style
+			end
 		end
 		
 		if !nzRound:InState( ROUND_CREATE ) then return end

--- a/gamemodes/nzombies/entities/entities/random_box_windup/shared.lua
+++ b/gamemodes/nzombies/entities/entities/random_box_windup/shared.lua
@@ -70,7 +70,7 @@ function ENT:Use( activator, caller )
 			self.Box:Close()
 			self:Remove()
 		else
-			if self.Buyer:IsValid() then
+			if IsValid(self.Buyer) then
 				activator:PrintMessage( HUD_PRINTTALK, "This is " .. self.Buyer:Nick() .. "'s gun. You cannot take it." )
 			end
 		end

--- a/gamemodes/nzombies/gamemode/function_override/sh_meta.lua
+++ b/gamemodes/nzombies/gamemode/function_override/sh_meta.lua
@@ -53,7 +53,7 @@ if SERVER then
 			end
 		end
 	end
-	hook.Add("WeaponEquip", "ModifyWeaponReloads", ReplaceReloadFunction)
+	hook.Add("WeaponEquip", "nzModifyWeaponReloads", ReplaceReloadFunction)
 	
 	function ReplacePrimaryFireCooldown(wep)
 		local oldfire = wep.PrimaryAttack
@@ -73,7 +73,7 @@ if SERVER then
 			end
 		end
 	end
-	hook.Add("WeaponEquip", "ModifyWeaponNextFires", ReplacePrimaryFireCooldown)
+	hook.Add("WeaponEquip", "nzModifyWeaponNextFires", ReplacePrimaryFireCooldown)
 	
 	function ReplaceAimDownSight(wep)
 		local oldfire = wep.SecondaryAttack
@@ -97,9 +97,9 @@ if SERVER then
 			end
 		end
 	end
-	hook.Add("WeaponEquip", "ModifyAimDownSights", ReplaceAimDownSight)
+	hook.Add("WeaponEquip", "nzModifyAimDownSights", ReplaceAimDownSight)
 	
-	hook.Add("DoAnimationEvent", "ReloadCherry", function(ply, event, data)
+	hook.Add("DoAnimationEvent", "nzReloadCherry", function(ply, event, data)
 		--print(ply, event, data)
 		if event == PLAYERANIMEVENT_RELOAD then
 			if ply:HasPerk("cherry") then

--- a/gamemodes/nzombies/gamemode/mapping/sv_mapping.lua
+++ b/gamemodes/nzombies/gamemode/mapping/sv_mapping.lua
@@ -361,13 +361,14 @@ function nzMapping:CleanUpMap()
 	end
 	
 	-- Remove gamemode-specific entities if their gamemode hasn't be enabled in the Map Settings menu
-	for k,v in pairs(ents.GetAll()) do
+	--[[for k,v in pairs(ents.GetAll()) do
 		if v.NZGamemodeExtension then
 			if !nzMapping.Settings.gamemodeentities[v.NZGamemodeExtension] then
 				v:Remove()
 			end
 		end
-	end
+	end]]
+	-- No longer done here, done in the entities' Initialize function
 end
 
 function nzMapping:SpawnEntity(pos, ang, ent, ply)

--- a/gamemodes/nzombies/gamemode/player_class/sv_players.lua
+++ b/gamemodes/nzombies/gamemode/player_class/sv_players.lua
@@ -42,7 +42,7 @@ local function initialSpawn( ply )
 end
 
 local function playerLeft( ply )
-	-- this was previously hooked to  PlayerDisconnected
+	-- this was previously hooked to PlayerDisconnected
 	-- it will now detect leaving players via entity removed, to take kicking banning etc into account.
 	if ply:IsPlayer() then
 		ply:DropOut()

--- a/gamemodes/nzombies/gamemode/ragdoll/cl_zombierags.lua
+++ b/gamemodes/nzombies/gamemode/ragdoll/cl_zombierags.lua
@@ -1,8 +1,12 @@
+if not ConVarExists("nz_ragdolltime") then CreateConVar("nz_ragdolltime", 30, {FCVAR_ARCHIVE}, "How long Zombie ragdolls will stay in the map.") end
+
 function GM:CreateClientsideRagdoll( ent, ragdoll )
-	local dTime = math.random( 30, 60 )
+	local convar = GetConVar("nz_ragdolltime"):GetInt()
+	local dTime = math.random( convar*0.75, convar*1.25 )
 
 	if ent:GetDecapitated() then
 		local bone = ragdoll:LookupBone("ValveBiped.Bip01_Head1")
+		if !bone then bone = ragdoll:LookupBone("j_head") end
 
 		if bone then
 			ragdoll:ManipulateBoneScale(bone, Vector(0.00001,0.00001,0.00001))
@@ -35,4 +39,6 @@ function GM:CreateClientsideRagdoll( ent, ragdoll )
 	end)
 	]]--
 	SafeRemoveEntityDelayed( ragdoll, dTime + 2.5 )
+	
+	--print("Client side ragdoll")
 end

--- a/gamemodes/nzombies/gamemode/revive_system/sh_revival.lua
+++ b/gamemodes/nzombies/gamemode/revive_system/sh_revival.lua
@@ -152,7 +152,7 @@ function Revive:RespawnWithWhosWho(ply, pos)
 		local maxdist = 1500^2
 		local mindist = 500^2
 
-		local available = ents.FindByClass("zed_special_spawns")
+		local available = ents.FindByClass("nz_spawn_zombie_special")
 		if IsValid(available[1]) then
 			for k,v in pairs(available) do
 				local dist = plypos:DistToSqr(v:GetPos())

--- a/gamemodes/nzombies/gamemode/tools/sh_tools_wallbuy.lua
+++ b/gamemodes/nzombies/gamemode/tools/sh_tools_wallbuy.lua
@@ -58,10 +58,12 @@ nz.Tools.Functions.CreateTool("wallbuy", {
 		local Row1 = DProperties:CreateRow( "Weapon Settings", "Weapon Class" )
 		Row1:Setup( "Combo" )
 		for k,v in pairs(weapons.GetList()) do
-			if v.Category and v.Category != "" then
-				Row1:AddChoice(v.PrintName and v.PrintName != "" and v.Category.. " - "..v.PrintName or v.ClassName, v.ClassName, false)
-			else
-				Row1:AddChoice(v.PrintName and v.PrintName != "" and v.PrintName or v.ClassName, v.ClassName, false)
+			if !v.NZTotalBlacklist then
+				if v.Category and v.Category != "" then
+					Row1:AddChoice(v.PrintName and v.PrintName != "" and v.Category.. " - "..v.PrintName or v.ClassName, v.ClassName, false)
+				else
+					Row1:AddChoice(v.PrintName and v.PrintName != "" and v.PrintName or v.ClassName, v.ClassName, false)
+				end
 			end
 		end
 		Row1.DataChanged = function( _, val ) valz["Row1"] = val UpdateData() end


### PR DESCRIPTION
- Added Elec option to Dynamic Lights - makes them only turn on when
electricity is on
- Added convar "nz_ragdolltime" which sets how long it takes for a
ragdoll to disappear
- All powerups' sizes increased from 50 to 60
- All powerups now use a think-based logic rather than a timer
- Tombstone now only starts its 90 second timer when its owner has
respawned
- Changed a few comments and way of handling things
- Changed function override hook names to all be prefixed with "nz"
- Decapitated CoD-skeleton ragdolls now also remove the head
- Fixed Who's Who not respawning players on Special Spawnpoints
- Fixed Wall Buy tool ignoring NZTotalBlacklist