### PR TITLE
Fire Zombie Lag Fix

### DIFF
--- a/gamemodes/nzombies/entities/entities/nz_zombiebase.lua
+++ b/gamemodes/nzombies/entities/entities/nz_zombiebase.lua
@@ -183,6 +183,8 @@ function ENT:Initialize()
 		self:SetBodygroup( i-1, math.random(0, self:GetBodygroupCount(i-1) - 1))
 	end
 	self:SetSkin( math.random(self:SkinCount()) - 1 )
+	
+	self.ZombieAlive = true
 
 end
 
@@ -588,6 +590,10 @@ function ENT:OnZombieDeath()
 	self:BecomeRagdoll(dmgInfo)
 end
 
+function ENT:Alive()
+	return self.ZombieAlive
+end
+
 function ENT:OnKilled(dmgInfo)
 
 	if dmgInfo then
@@ -606,6 +612,8 @@ function ENT:OnKilled(dmgInfo)
 			self:SetDecapitated(true)
 		end
 	end
+	
+	self.ZombieAlive = false
 
 	hook.Call("OnZombieKilled", GAMEMODE, self, dmgInfo)
 
@@ -1040,7 +1048,7 @@ function ENT:Flames( state )
 	end
 end
 
-function ENT:Explode( dmg, suicide)
+function ENT:Explode(dmg, suicide)
 
 	suicide = suicide or true
 

--- a/gamemodes/nzombies/gamemode/enemies/sv_hooks.lua
+++ b/gamemodes/nzombies/gamemode/enemies/sv_hooks.lua
@@ -46,7 +46,7 @@ function GM:EntityTakeDamage(zombie, dmginfo)
 	-- Who's Who clones can't take damage!
 	if zombie:GetClass() == "whoswho_downed_clone" then return true end
 	
-	if nzConfig.ValidEnemies[zombie:GetClass()] and zombie:Health() < 0 then zombie:SetHealth(1) end
+	if zombie.Alive and zombie:Alive() and zombie:Health() < 0 then zombie:SetHealth(1) end
 
 	if !dmginfo:GetAttacker():IsPlayer() then return end
 	if IsValid(zombie) and nzConfig.ValidEnemies[zombie:GetClass()] and nzConfig.ValidEnemies[zombie:GetClass()].Valid then


### PR DESCRIPTION
- Fixed Fire Zombies causing immense lag and sometimes crashes when
killed with explosive weapons